### PR TITLE
Fix to assertion for non-64-bit targets

### DIFF
--- a/src/str.rs
+++ b/src/str.rs
@@ -17,7 +17,7 @@ enum State<'a> {
 }
 
 const _: () = {
-    assert!(mem::size_of::<State>() == 24);
+    assert!(mem::size_of::<State>() == mem::size_of::<Vec<u8>>());
 };
 
 #[repr(transparent)]


### PR DESCRIPTION
In `src/str.rs`, there is an assertion on the size of `str::State`, presumably to ensure that enum niche optimization is working as expected. Unfortunately, it hard-coded the size of `State` to be 24 bytes. On 64-bit systems, that _is_ the expected value (if niche optimization shrinks `State` to the 3-word size of a `Vec<u8>`)... but that is not the correct size on systems with a different word size.

This pull request changes the size to whatever the size of `Vec<u8>` on the target is.